### PR TITLE
Fixed CSS

### DIFF
--- a/weblate_web/static/style-rtl.css
+++ b/weblate_web/static/style-rtl.css
@@ -319,7 +319,9 @@ a.button:hover, input.button:hover {
 }
 a.button.inline, input.button.inline {
 	display: inline-block;
-	margin: 0 15px;
+	margin-bottom: 10px;
+	margin-left: 5px;
+	margin-right: 5px;
 }
 a.button.right, input.button.right {
 	float: left;


### PR DESCRIPTION
#Bug #Hacktoberfest

![image](https://user-images.githubusercontent.com/5537822/67377871-c2e67880-f59f-11e9-82ad-52513975b7ad.png)


Some images are wrongly displayed in RTL mode - the rounded corners are on wrong side and logo or avatar are on screen side instead of center. Mostly on https://weblate.org/ar/donate/ and https://weblate.org/ar/about/.

Possible fixes:

apply CSS transform
use original images and place them using CSS